### PR TITLE
fix entropy bug in acronym generator

### DIFF
--- a/js/alternate.js
+++ b/js/alternate.js
@@ -141,7 +141,7 @@ function generateAcronym(wordCount, wordList, useEntropy) {
 
   const num = secRand(candidates.length, useEntropy)
   const acronym = candidates[num]
-  const initEntropy = Math.log2(candidates.length)
+  const initEntropy = candidates.length
   const entropies = [initEntropy]
   const passphraseWords = []
 


### PR DESCRIPTION
From my understanding, I think there is an entropy bug in the new acronym generator. 

I was doing some `console.log` checks to help me understand how you were doing the entropy math and I noticed that the `entropies` variable seemed to have different types:
![image](https://user-images.githubusercontent.com/5581855/192051967-116fef3b-bf4e-4eb4-a803-9a99089fe1a3.png)

The first item in the `entropies` list already has `Math.log2` applied to it, but the rest of the items don't. 

Then in the `getSecurity` function you run `Math.log2` on all the items in `entropies` and then sum them together to get the final bit count. I think this causes the first item to have `Math.log2` applied to it twice, screwing up a correct bit count. 

This makes you underestimate the true entropy.  